### PR TITLE
Implement python script to create new .oxt file

### DIFF
--- a/docs/how-to-release-a-new-version.md
+++ b/docs/how-to-release-a-new-version.md
@@ -1,0 +1,52 @@
+### How to release a new version?
+
+After developing a new version, the files have to be packed in an `.oxt` file. Such an extension is essentially a `.zip` file with altered extension.
+
+We have a script called `release.py` in order to automate this process. Examples:
+
+##### Releasing a version `0.0.3` for LibreOffice:
+
+```bash
+./release.py --LibreOffice 0.0.3
+```
+
+##### Releasing a version `0.0.3` for OpenOffice:
+
+```bash
+./release.py --OpenOffice 0.0.3
+```
+
+##### Changing the final filename:
+
+```bash
+./release.py --OpenOffice 0.0.3 -f awesome-release
+```
+
+##### Changing the source folder:
+
+```bash
+./release.py --OpenOffice 0.0.3 -s ../lo-page-numbering
+```
+
+<br />
+<br />
+
+`./release.py --help`:
+
+```
+usage: release.py [-h] [-L] [-O] [-s SOURCE] [-f FILENAME] version
+
+Release a new version
+
+positional arguments:
+  version               version (e.g., 0.1.0)
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -L, --LibreOffice     for LibreOffice
+  -O, --OpenOffice      for OpenOffice
+  -s SOURCE, --source SOURCE
+                        source folder
+  -f FILENAME, --filename FILENAME
+                        filename
+```

--- a/release.py
+++ b/release.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import os
+import zipfile
+import argparse
+
+def zipall(ob, path, rel=""):
+    basename = os.path.basename(path)
+    if os.path.isdir(path):
+        if rel == "":
+            rel = basename
+        ob.write(path, os.path.join(rel))
+        for root, dirs, files in os.walk(path):
+            for d in dirs:
+                zipall(ob, os.path.join(root, d), os.path.join(rel, d))
+            for f in files:
+                ob.write(os.path.join(root, f), os.path.join(rel, f))
+            break
+    elif os.path.isfile(path):
+        ob.write(path, os.path.join(rel, basename))
+    else:
+        pass
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Release a new version')
+    parser.add_argument('version', type=str, help='version (e.g., 0.1.0)')
+    
+    args = parser.parse_args()
+
+    release = args.version.replace('.', '_')
+    release_dir = 'LibreOffice/versions/{}'.format(release)
+
+    os.makedirs(release_dir, exist_ok=True)
+
+    files_dir = 'OpenOffice/python/oxt_metadata'
+    oxt_file = '{}/PageNumberingAddon.oxt'.format(release_dir)
+
+    with zipfile.ZipFile(oxt_file, "w") as oxt:
+        for f in os.listdir(files_dir):
+            zipall(oxt, os.path.join(files_dir, f))
+    
+    print('Release file available in {}'.format(oxt_file))

--- a/release.py
+++ b/release.py
@@ -24,16 +24,26 @@ def zipall(ob, path, rel=""):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Release a new version')
     parser.add_argument('version', type=str, help='version (e.g., 0.1.0)')
+    parser.add_argument('--source', dest='source', default=os.getcwd(),
+                        type=str, help='source folder')
+    parser.add_argument('--filename', dest='filename', default='PageNumberingAddon',
+                        type=str, help='filename')
     
     args = parser.parse_args()
 
     release = args.version.replace('.', '_')
-    release_dir = 'LibreOffice/versions/{}'.format(release)
+    release_dir = os.path.join(
+        args.source,
+        'LibreOffice/versions/{}'.format(release)
+    )
 
     os.makedirs(release_dir, exist_ok=True)
 
-    files_dir = 'OpenOffice/python/oxt_metadata'
-    oxt_file = '{}/PageNumberingAddon.oxt'.format(release_dir)
+    files_dir = os.path.join(
+        args.source,
+        'OpenOffice/python/oxt_metadata'
+    )
+    oxt_file = '{}/{}.oxt'.format(release_dir, args.filename)
 
     with zipfile.ZipFile(oxt_file, "w") as oxt:
         for f in os.listdir(files_dir):


### PR DESCRIPTION
Usage:

```bash
# releasing 0.0.3 version for LibreOffice
./release.py -L 0.0.3
# or change the source folder
./release.py -L 0.0.3 --source=/home/some/path
# you can also change the output filename
./release.py -L 0.0.3 --filename=awesome-release-v0.0.3
```

Fix: #15 